### PR TITLE
Avoid PHP Warning on FTP Connection

### DIFF
--- a/src/Adapter/Ftp.php
+++ b/src/Adapter/Ftp.php
@@ -423,6 +423,9 @@ class Ftp extends AbstractFtpAdapter
      */
     public function isConnected()
     {
+        if ( is_bool($this->connection) || is_null($this->connection) ) {
+            return false;
+        }
         return ! is_null($this->connection) && ftp_systype($this->connection) !== false;
     }
 }


### PR DESCRIPTION
If `$this->connection` has failed and is a boolean, calling `ftp_systype($this->connection)` throws a PHP warning (Warning: ftp_systype() expects parameter 1 to be resource, boolean given). I propose first checking to see if $this->connection is a resource or a boolean/null and if it's going to fail anyway, to start the failure sooner.
